### PR TITLE
add jest-compact-reporter

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  reporters: ["default", "jest-html-reporters"],
+  reporters: ["default", "jest-html-reporters", "jest-compact-reporter"],
   preset: "@shelf/jest-mongodb",
 };

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@shelf/jest-mongodb": "^4.1.4",
         "jest": "^29.3.1",
+        "jest-compact-reporter": "^1.2.9",
         "jest-html-reporters": "^3.0.11",
         "mongodb-memory-server": "^8.10.1",
         "nodemon": "^2.0.20",
@@ -4890,6 +4891,15 @@
         "node-notifier": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "dependencies": {
+        "assert-never": "^1.2.1"
       }
     },
     "node_modules/jest-config": {
@@ -11875,6 +11885,15 @@
         "jest-validate": "^29.3.1",
         "prompts": "^2.0.1",
         "yargs": "^17.3.1"
+      }
+    },
+    "jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "requires": {
+        "assert-never": "^1.2.1"
       }
     },
     "jest-config": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@shelf/jest-mongodb": "^4.1.4",
     "jest": "^29.3.1",
+    "jest-compact-reporter": "^1.2.9",
     "jest-html-reporters": "^3.0.11",
     "mongodb-memory-server": "^8.10.1",
     "nodemon": "^2.0.20",

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -41,6 +41,7 @@
         "@jest/types": "^29.3.1",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
+        "jest-compact-reporter": "^1.2.9",
         "jest-html-reporters": "^3.0.11",
         "msw": "^0.49.0"
       }
@@ -6034,6 +6035,12 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "node_modules/assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
+      "dev": true
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -11590,6 +11597,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "dependencies": {
+        "assert-never": "^1.2.1"
       }
     },
     "node_modules/jest-config": {
@@ -24624,6 +24640,12 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
+    "assert-never": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.2.1.tgz",
+      "integrity": "sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==",
+      "dev": true
+    },
     "ast-types-flow": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -28657,6 +28679,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "jest-compact-reporter": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/jest-compact-reporter/-/jest-compact-reporter-1.2.9.tgz",
+      "integrity": "sha512-s8SsyiFQu9aniDyZ/t7FAEVxjMzUryHM7e1Leef4DZwyDCNJyGUclREJyvi4cN9yCtu7PSXx3ms47OqpFzUA4w==",
+      "dev": true,
+      "requires": {
+        "assert-never": "^1.2.1"
       }
     },
     "jest-config": {

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --reporters=default --reporters=jest-html-reporters",
+    "test": "react-scripts test --reporters=default --reporters=jest-html-reporters --reporters jest-compact-reporter",
+    "ci:test": "react-scripts test --reporters=default --reporters jest-compact-reporter",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -68,6 +69,7 @@
     "@jest/types": "^29.3.1",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",
+    "jest-compact-reporter": "^1.2.9",
     "jest-html-reporters": "^3.0.11",
     "msw": "^0.49.0"
   }


### PR DESCRIPTION
In the CI it can be hard to see which tests failed with the default reporter.
This will add a compact reporter after the default reporter to display all the important information in a compact format.